### PR TITLE
Added ufw rule to deny incoming connections for debian hosts

### DIFF
--- a/tasks/persist-debian.yml
+++ b/tasks/persist-debian.yml
@@ -5,6 +5,11 @@
 - name: Copy v4 restore script
   template: src=restore.v4.j2 dest=/etc/network/if-pre-up.d/iptables-v4 owner=root group=root mode=755
 
+- name: Drop incoming connections
+  ufw:
+    direction: incoming
+    policy: deny
+
 - name: Enable firewall rule to limit incoming ssh trafic
   ufw:
     rule: limit


### PR DESCRIPTION
As requested by security, adding a ufw rule to deny incoming connections. This has been tested on my machine and does not impact web browsing, curl or docker pulls.